### PR TITLE
fixed bug with typechecker for boolean arrays

### DIFF
--- a/jaxtyping/array_types.py
+++ b/jaxtyping/array_types.py
@@ -88,9 +88,7 @@ _AbstractDim = Union[Literal[_anonymous_dim], _NamedDim, _FixedDim, _SymbolicDim
 
 
 def _check_dims(
-    cls_dims: List[_AbstractDim],
-    obj_shape: Tuple[int],
-    single_memo: Dict[str, int],
+    cls_dims: List[_AbstractDim], obj_shape: Tuple[int], single_memo: Dict[str, int],
 ) -> bool:
     assert len(cls_dims) == len(obj_shape)
     for cls_dim, obj_size in zip(cls_dims, obj_shape):
@@ -446,7 +444,7 @@ if TYPE_CHECKING:
     from typing_extensions import Annotated as UInt32
     from typing_extensions import Annotated as UInt64
 else:
-    _bool = "bool"
+    _bool = "bool_"
     _uint8 = "uint8"
     _uint16 = "uint16"
     _uint32 = "uint32"


### PR DESCRIPTION
Hi @patrick-kidger ,

thanks again for this excellent library!

When using it extensively in my current project, I realized that there is a minor bug / inconsistency when handling boolean jax arrays. - see PR. 

As far as I could see it the modification does not break anything. However, before the following was failing for me

```python
import jax.numpy as jnp
from jaxtyping import Bool, Array

isinstance(jnp.array(1 > 0), Bool[Array, "..."])
```