### PR TITLE
Add support for e.g. jaxtyping.Float[Union[...], ...] in py3.8

### DIFF
--- a/jaxtyping/array_types.py
+++ b/jaxtyping/array_types.py
@@ -385,7 +385,7 @@ class _MetaAbstractDtype(type):
             dims.append(elem)
         if _array_name_format == "dtype_and_shape":
             # In python 3.8, e.g., typing.Union lacks `__name__`.
-            type_str = getattr(array_type, '__name__', None) or repr(array_type)
+            type_str = getattr(array_type, "__name__", None) or repr(array_type)
             name = f"{cls.__name__}[{type_str}, '{dim_str}']"
         elif _array_name_format == "array":
             name = array_type.__name__

--- a/jaxtyping/array_types.py
+++ b/jaxtyping/array_types.py
@@ -384,7 +384,9 @@ class _MetaAbstractDtype(type):
                 elem = _SymbolicDim(elem, broadcastable)
             dims.append(elem)
         if _array_name_format == "dtype_and_shape":
-            name = f"{cls.__name__}[{array_type.__name__}, '{dim_str}']"
+            # In python 3.8, e.g., typing.Union lacks `__name__`.
+            type_str = getattr(array_type, '__name__', None) or repr(array_type)
+            name = f"{cls.__name__}[{type_str}, '{dim_str}']"
         elif _array_name_format == "array":
             name = array_type.__name__
         else:

--- a/jaxtyping/array_types.py
+++ b/jaxtyping/array_types.py
@@ -385,7 +385,10 @@ class _MetaAbstractDtype(type):
             dims.append(elem)
         if _array_name_format == "dtype_and_shape":
             # In python 3.8, e.g., typing.Union lacks `__name__`.
-            type_str = getattr(array_type, "__name__", None) or repr(array_type)
+            try:
+                type_str = array_type.__name__
+            except AttributeError:
+                type_str = repr(array_type)
             name = f"{cls.__name__}[{type_str}, '{dim_str}']"
         elif _array_name_format == "array":
             name = array_type.__name__


### PR DESCRIPTION
Turns out that python3.8, Union lacks the __name__ attribute.  Use repr() in these cases.