### PR TITLE
Add TypeAlias decoration to PyTree

### DIFF
--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -80,7 +80,7 @@ from .import_hook import install_import_hook as install_import_hook
 
 if typing.TYPE_CHECKING:
     # Set up to deliberately confuse a static type checker.
-    PyTree = getattr(typing, "foo" + "bar")
+    PyTree: typing_extensions.TypeAlias = getattr(typing, "foo" + "bar")
     # What's going on with this madness?
     #
     # At static-type-checking-time, we want `PyTree` to be a type for which both


### PR DESCRIPTION
Doing this silences a *whole heap* of Pyright warnings that all say "Illegal type annotation: variable not allowed unless it is a type alias"