### PR TITLE
We now have `Float[np.ndarray, ...] <: np.ndarray`. Added basic torch tests.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
         with:
             python-version: "3.8"
             test-script: |
-                python -m pip install pytest beartype equinox jaxlib
+                python -m pip install pytest beartype equinox jaxlib cloudpickle
+                python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
                 cp -r ${{ github.workspace }}/test ./test
                 pytest
             pypi-token: ${{ secrets.pypi_token }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest wheel beartype equinox jaxlib
+          python -m pip install pytest wheel beartype equinox jaxlib cloudpickle
+          python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Checks with pre-commit
         uses: pre-commit/action@v2.0.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,8 @@ Now make your changes. Make sure to include additional tests if necessary.
 Next verify the tests all pass:
 
 ```bash
-pip install pytest
+pip install pytest cloudpickle
+pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
 pytest
 ```
 

--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -90,6 +90,8 @@ from .import_hook import install_import_hook as install_import_hook
 
 if typing.TYPE_CHECKING:
     # Set up to deliberately confuse a static type checker.
+    import typing_extensions
+
     PyTree: typing_extensions.TypeAlias = getattr(typing, "foo" + "bar")
     # What's going on with this madness?
     #

--- a/test/test_serialisation.py
+++ b/test/test_serialisation.py
@@ -1,4 +1,6 @@
 import cloudpickle
+import numpy as np
+import torch
 
 from jaxtyping import AbstractArray, Array, Shaped
 
@@ -6,5 +8,9 @@ from jaxtyping import AbstractArray, Array, Shaped
 def test_pickle():
     x = cloudpickle.dumps(Shaped[Array, ""])
     y = cloudpickle.dumps(AbstractArray)
+    z = cloudpickle.dumps(Shaped[np.ndarray, ""])
+    w = cloudpickle.dumps(Shaped[torch.Tensor, ""])
     cloudpickle.loads(x)
     cloudpickle.loads(y)
+    cloudpickle.loads(z)
+    cloudpickle.loads(w)


### PR DESCRIPTION
This required quite a lot of refactoring! JAX supports virtual subclass registration (its metaclass is ABCMeta) but NumPy does not, so we have to actually subclass `np.ndarray`. Simple stuff like __base__ hacking fails due to deallocator conflicts.