### PR TITLE
Fix jaxtyping on ARM Linux

### DIFF
--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -21,20 +21,13 @@ import importlib.metadata
 import typing
 
 
-try:
-    import jax
-except ImportError:
-    has_jax = False
-else:
-    has_jax = True
-    del jax
-
 # First import some things as normal
 from ._array_types import (
     AbstractArray as AbstractArray,
     AbstractDtype as AbstractDtype,
     get_array_name_format as get_array_name_format,
     set_array_name_format as set_array_name_format,
+    has_jax
 )
 from ._decorator import jaxtyped as jaxtyped
 from ._import_hook import install_import_hook as install_import_hook

--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -26,8 +26,8 @@ from ._array_types import (
     AbstractArray as AbstractArray,
     AbstractDtype as AbstractDtype,
     get_array_name_format as get_array_name_format,
-    set_array_name_format as set_array_name_format,
     has_jax,
+    set_array_name_format as set_array_name_format,
 )
 from ._decorator import jaxtyped as jaxtyped
 from ._import_hook import install_import_hook as install_import_hook

--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -27,7 +27,7 @@ from ._array_types import (
     AbstractDtype as AbstractDtype,
     get_array_name_format as get_array_name_format,
     set_array_name_format as set_array_name_format,
-    has_jax
+    has_jax,
 )
 from ._decorator import jaxtyped as jaxtyped
 from ._import_hook import install_import_hook as install_import_hook

--- a/jaxtyping/_array_types.py
+++ b/jaxtyping/_array_types.py
@@ -32,7 +32,12 @@ from ._decorator import storage
 
 try:
     import jax
-except ImportError:
+except (ImportError, RuntimeError, AttributeError):
+    # Note: We catch "RuntimeError" and "AttributeError" here instead of
+    # just ImportError as `jax` will throw a RuntimeError if it's present
+    # but unable to run on the current machine, which then leads the module
+    # to be left partially initialized, causing subsequent imports to fail with
+    # 'AttributeError: partially initialized module'
     has_jax = False
 else:
     has_jax = True


### PR DESCRIPTION
`jaxtyping` is causing crashes when running tests on hosts that have `jax` installed but are unable to import it (e.g. ARM Linux hosts).

For example:
```
...
  File "/root/.pyenv/versions/3.10.11/lib/python3.10/site-packages/jaxtyping/__init__.py", line 25, in <module>
    import jax
  File "/root/.pyenv/versions/3.10.11/lib/python3.10/site-packages/jax/__init__.py", line 35, in <module>
    from jax import config as _config_module
  File "/root/.pyenv/versions/3.10.11/lib/python3.10/site-packages/jax/config.py", line 17, in <module>
    from jax._src.config import config  # noqa: F401
  File "/root/.pyenv/versions/3.10.11/lib/python3.10/site-packages/jax/_src/config.py", line 27, in <module>
    from jax._src import lib
  File "/root/.pyenv/versions/3.10.11/lib/python3.10/site-packages/jax/_src/lib/__init__.py", line 84, in <module>
    cpu_feature_guard.check_cpu_features()
RuntimeError: This version of jaxlib was built using AVX instructions, which your CPU and/or operating system do not support. You may be able work around this issue by building jaxlib from source.
```

`jax` will throw a RuntimeError if it's present but unable to run on the current machine, which then leads the module to be left partially initialized, causing subsequent imports to fail with 'AttributeError: partially initialized module'