### PR TITLE
dataclasses now have fields checked, not __init__.

### DIFF
--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -19,6 +19,7 @@
 
 import importlib.metadata
 import typing
+import warnings
 
 # First import some things as normal
 from ._array_types import (
@@ -194,6 +195,22 @@ elif has_jax:
         from ._array_types import PRNGKeyArray
 
 del has_jax
+
+
+check_equinox_version = True  # easy-to-replace line with copybara
+if check_equinox_version:
+    try:
+        eqx_version = importlib.metadata.version("equinox")
+    except importlib.metadata.PackageNotFoundError:
+        pass
+    else:
+        major, minor, patch = eqx_version.split(".")
+        equinox_version = (int(major), int(minor), int(patch))
+        if equinox_version < (0, 11, 0):
+            warnings.warn(
+                "jaxtyping version >=0.2.23 should be used with Equinox version "
+                ">=0.11.1"
+            )
 
 
 __version__ = importlib.metadata.version("jaxtyping")

--- a/jaxtyping/_import_hook.py
+++ b/jaxtyping/_import_hook.py
@@ -326,8 +326,8 @@ def install_import_hook(modules: Union[str, Sequence[str]], typechecker: Optiona
         install_import_hook(["foo", "bar.baz"], ...)
         ```
 
-    The import hook will automatically decorate all functions, and the `__init__` method
-    of dataclasses.
+    The import hook will automatically decorate all functions, and check the attributes
+    assigned to dataclasses.
 
     If the function already has any decorators on it, then both the `@jaxtyped` and the
     typechecker decorators will get added at the bottom of the decorator list, e.g.
@@ -401,6 +401,28 @@ def install_import_hook(modules: Union[str, Sequence[str]], typechecker: Optiona
 
         (This is the author's preferred approach to performing runtime type-checking
         with jaxtyping!)
+
+    !!! warning
+
+        Stringified dataclass annotations, e.g.
+        ```python
+        @dataclass()
+        class Foo:
+            x: "int"
+        ```
+        will be silently skipped without checking them. This is because these are
+        essentially impossible to resolve at runtime. Such stringified annotations
+        typically occur either when using them for forward references, or when using
+        `from __future__ import annotations`. (You should never use the latter, it is
+        largely incompatible with runtime type checking.)
+
+        Partially stringified dataclass annotations, e.g.
+        ```python
+        @dataclass()
+        class Foo:
+            x: tuple["int"]
+        ```
+        will likely raise an error, and must not be used at all.
     """  # noqa: E501
 
     if isinstance(modules, str):


### PR DESCRIPTION
Previously, using the import hook with dataclasses resulted in the `__init__` method of the dataclass being checked.
This was undesirable when using `eqx.field(converter=...)`, as the annotation didn't necessarily reflect the argument type.
A typical example was
```python
class Foo(eqx.Module):
    x: jax.Array = eqx.field(converter=jnp.ndarray)

Foo(1)  # 1 is not an array! But this code is valid.
```

After this change, we instead monkey-patch our checks to happen at the end of the `__init__` of the dataclass -- after conversion has run.

Note that this requires https://github.com/patrick-kidger/equinox/pull/524. Otherwise, Equinox does conversion too late (in `_ModuleMeta.__call__`, after `__init__` has been run).

(This is also the reason for the test failure at the moment, which is spurious -- I've checked that this passes locally. I'll merge this PR once Equinox v0.11.0 is released.)
