### PR TITLE
Fix flakiness of transitive import hook test

### DIFF
--- a/test/test_import_hook.py
+++ b/test/test_import_hook.py
@@ -125,6 +125,8 @@ def test_import_hook_transitive(importhook_tempdir):
     with open(transitive_dir / "__init__.py", "w") as f:
         f.write("from . import tester")
         f.flush()
+
+    importlib.invalidate_caches()
     with jaxtyping.install_import_hook(transitive_name, typechecker):
         importlib.import_module(transitive_name)
     assert counter + 1 == jaxtyping._test_import_hook_counter


### PR DESCRIPTION
Fixing #121 .

I spent a bit of time trying to figure out what is wrong, and discovered that importlib had some issues. Instead of figuring out what exactly is the problem, I am just invalidating caches..