### PR TITLE
Bump up pre-commit ruff and black versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,11 +19,11 @@
 
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 23.9.1
     hooks:
     - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.255'
+    rev: 'v0.0.291'
     hooks:
       - id: ruff
         args: ["--fix"]


### PR DESCRIPTION
Noticed that the versions are almost a year old. Also this (might) fix a warning in GitHub actions.