### PR TITLE
Allow only typeguard lower than 3.x.x version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/google/jaxtyping" }
-dependencies = ["numpy>=1.20.0", "typeguard>=2.13.3", "typing_extensions>=3.7.4.1"]
+dependencies = ["numpy>=1.20.0", "typeguard>=2.13.3,<3", "typing_extensions>=3.7.4.1"]
 entry-points = {pytest11 = {jaxtyping = "jaxtyping._pytest_plugin"}}
 
 [build-system]


### PR DESCRIPTION
Hi Patrick,

I noticed that in ```pyproject.toml``` there is no constraint on the highest allowed version of typeguard, eventhough it looks like there should be. [PEP 508](https://peps.python.org/pep-0508/) explains how does version notation work, and thus I just introduced this constraint.