### PR TITLE
Pretty error messages: fixes #6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Type annotations **and runtime type-checking** for:
 ```python
 from jaxtyping import Array, Float, PyTree
 
-# Accepts floating-point 2D arrays with matching dimensions
+# Accepts floating-point 2D arrays with matching axes
 def matrix_multiply(x: Float[Array, "dim1 dim2"],
                     y: Float[Array, "dim2 dim3"]
                   ) -> Float[Array, "dim1 dim3"]:

--- a/docs/api/array.md
+++ b/docs/api/array.md
@@ -24,7 +24,7 @@ In addition some modifiers can be applied:
     `def add(x: Float[Array, "#foo"], y: Float[Array, "#foo"]) -> Float[Array, "#foo"]`.
 - Prepend `_` to a dimension to disable any runtime checking of that dimension (so that it can be used just as documentation). This can also be used as just `_` on its own: e.g. `"b c _ _"`.
 - Documentation-only names (i.e. they're ignored by jaxtyping) can be handled by prepending a name followed by `=` e.g. `Float[Array, "rows=4 cols=3"]`.
-- Prepend `?` to a dimension to indicate that its size can vary within a PyTree structure. (See [PyTree annotations](../pytree.md).)
+- Prepend `?` to a dimension to indicate that its size can vary within a PyTree structure. (See [PyTree annotations](../pytree/).)
 
 When using multiple modifiers, their order does not matter.
 

--- a/docs/api/array.md
+++ b/docs/api/array.md
@@ -41,7 +41,7 @@ As a special case:
 - A symbolic expression cannot be evaluated unless all of the axes sizes it refers to have already been processed. In practice this usually means that they should only be used in annotations for the return type, and only use axes declared in the arguments.
 - Symbolic expressions are evaluated in two stages: they are first evaluated as f-strings using the arguments of the function, and second are evaluated using the processed axis sizes. The f-string evaluation means that they can use local variables by enclosing them with curly braces, e.g. `{variable}`, e.g.
     ```python
-    def full(size: int, fill: float) -> Float[Array, "{shape}"]:
+    def full(size: int, fill: float) -> Float[Array, "{size}"]:
         return jax.numpy.full((size,), fill)
 
     class SomeClass:

--- a/docs/api/array.md
+++ b/docs/api/array.md
@@ -19,12 +19,12 @@ When calling a function, variable-size axes and symbolic axes will be matched up
 
 In addition some modifiers can be applied:
 
-- Prepend `*` to a dimension to indicate that it can match multiple axes, e.g. `"*batch c h w"` will match zero or more batch axes.
-- Prepend `#` to a dimension to indicate that it can be that size *or* equal to one -- i.e. broadcasting is acceptable, e.g.  
+- Prepend `*` to an axis to indicate that it can match multiple axes, e.g. `"*batch c h w"` will match zero or more batch axes.
+- Prepend `#` to an axis to indicate that it can be that size *or* equal to one -- i.e. broadcasting is acceptable, e.g.  
     `def add(x: Float[Array, "#foo"], y: Float[Array, "#foo"]) -> Float[Array, "#foo"]`.
-- Prepend `_` to a dimension to disable any runtime checking of that dimension (so that it can be used just as documentation). This can also be used as just `_` on its own: e.g. `"b c _ _"`.
+- Prepend `_` to an axis to disable any runtime checking of that axis (so that it can be used just as documentation). This can also be used as just `_` on its own: e.g. `"b c _ _"`.
 - Documentation-only names (i.e. they're ignored by jaxtyping) can be handled by prepending a name followed by `=` e.g. `Float[Array, "rows=4 cols=3"]`.
-- Prepend `?` to a dimension to indicate that its size can vary within a PyTree structure. (See [PyTree annotations](../pytree/).)
+- Prepend `?` to an axis to indicate that its size can vary within a PyTree structure. (See [PyTree annotations](../pytree/).)
 
 When using multiple modifiers, their order does not matter.
 
@@ -37,7 +37,7 @@ As a special case:
 - To denote a scalar shape use `""`, e.g. `Float[Array, ""]`.
 - To denote an arbitrary shape (and only check dtype) use `"..."`, e.g. `Float[Array, "..."]`.
 - You cannot have more than one use of multiple-axes, i.e. you can only use `...` or `*name` at most once in each array.
-- An example of broadcasting multiple dimensions:  
+- An example of broadcasting multiple axes:  
     `def add(x: Float[Array, "*#foo"], y: Float[Array, "*#foo"]) -> Float[Array, "*#foo"]`.
 - A symbolic expression cannot be evaluated unless all of the axes sizes it refers to have already been processed. In practice this usually means that they should only be used in annotations for the return type, and only use axes declared in the arguments.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ The annotations provided by jaxtyping are compatible with runtime type-checking 
 ```python
 from jaxtyping import Array, Float, PyTree
 
-# Accepts floating-point 2D arrays with matching dimensions
+# Accepts floating-point 2D arrays with matching axes
 def matrix_multiply(x: Float[Array, "dim1 dim2"],
                     y: Float[Array, "dim2 dim3"]
                   ) -> Float[Array, "dim1 dim3"]:

--- a/jaxtyping/__init__.py
+++ b/jaxtyping/__init__.py
@@ -29,7 +29,7 @@ from ._array_types import (
     has_jax,
     set_array_name_format as set_array_name_format,
 )
-from ._decorator import jaxtyped as jaxtyped
+from ._decorator import jaxtyped as jaxtyped, TypeCheckError as TypeCheckError
 from ._import_hook import install_import_hook as install_import_hook
 from ._ipython_extension import load_ipython_extension as load_ipython_extension
 

--- a/jaxtyping/_array_types.py
+++ b/jaxtyping/_array_types.py
@@ -127,10 +127,10 @@ def _check_dims(
             except NameError as e:
                 jaxtyping_raise_from(
                     NameError(
-                        f"Cannot process symbolic dimension '{cls_dim.elem_string}' as "
-                        "some dimension names have not been processed. In practice you "
-                        "should usually only use symbolic dimensions in annotations "
-                        "for return types, referring only to dimensions annotated for "
+                        f"Cannot process symbolic axis '{cls_dim.elem_string}' as "
+                        "some axis names have not been processed. In practice you "
+                        "should usually only use symbolic axes in annotations "
+                        "for return types, referring only to axes annotated for "
                         "arguments."
                     ),
                     e,
@@ -341,18 +341,18 @@ def _make_array(array_type, dim_str, dtypes, name):
         if "," in elem and "(" not in elem:
             # Common mistake.
             # Disable in the case that there's brackets to allow for function calls,
-            # e.g. `min(foo,bar)`, in symbolic dimensions.
-            raise ValueError("Dimensions should be separated with spaces, not commas")
+            # e.g. `min(foo,bar)`, in symbolic axes.
+            raise ValueError("Axes should be separated with spaces, not commas")
         if elem.endswith("#"):
             raise ValueError(
-                "As of jaxtyping v0.1.0, broadcastable dimensions are now denoted "
+                "As of jaxtyping v0.1.0, broadcastable axes are now denoted "
                 "with a # at the start, rather than at the end"
             )
 
         if "..." in elem:
             if elem != "...":
                 raise ValueError(
-                    "Anonymous multiple dimension '...' must be used on its own; "
+                    "Anonymous multiple axes '...' must be used on its own; "
                     f"got {elem}"
                 )
             broadcastable = False
@@ -382,7 +382,7 @@ def _make_array(array_type, dim_str, dtypes, name):
                     if variadic:
                         raise ValueError(
                             "Do not use * twice to denote accepting multiple "
-                            "dimensions, e.g. `**foo` is not allowed"
+                            "axes, e.g. `**foo` is not allowed"
                         )
                     variadic = True
                     elem = elem[1:]
@@ -421,7 +421,7 @@ def _make_array(array_type, dim_str, dtypes, name):
         if variadic:
             if index_variadic is not None:
                 raise ValueError(
-                    "Cannot use multiple-dimension specifiers (`*name` or `...`) "
+                    "Cannot use variadic specifiers (`*name` or `...`) "
                     "more than once."
                 )
             index_variadic = index
@@ -429,7 +429,7 @@ def _make_array(array_type, dim_str, dtypes, name):
         if dim_type is _DimType.fixed:
             if variadic:
                 raise ValueError(
-                    "Cannot have a fixed axis bind to multiple dimensions, e.g. "
+                    "Cannot have a fixed axis bind to multiple axes, e.g. "
                     "`*4` is not allowed."
                 )
             if anonymous:
@@ -446,7 +446,7 @@ def _make_array(array_type, dim_str, dtypes, name):
             if anonymous:
                 if broadcastable:
                     raise ValueError(
-                        "Cannot have a dimension be both anonymous and "
+                        "Cannot have an axis be both anonymous and "
                         "broadcastable, e.g. `#_` is not allowed."
                     )
                 if variadic:
@@ -462,17 +462,17 @@ def _make_array(array_type, dim_str, dtypes, name):
             assert dim_type is _DimType.symbolic
             if anonymous:
                 raise ValueError(
-                    "Cannot have a symbolic dimension be anonymous, e.g. "
+                    "Cannot have a symbolic axis be anonymous, e.g. "
                     "`_foo+bar` is not allowed"
                 )
             if variadic:
                 raise ValueError(
-                    "Cannot have symbolic multiple-dimensions, e.g. "
+                    "Cannot have symbolic multiple-axes, e.g. "
                     "`*foo+bar` is not allowed"
                 )
             if treepath:
                 raise ValueError(
-                    "Cannot have a symbolic dimensions with tree-path dependence, e.g. "
+                    "Cannot have a symbolic axis with tree-path dependence, e.g. "
                     "`?foo+bar` is not allowed"
                 )
             elem_string = elem
@@ -520,7 +520,7 @@ def _make_array(array_type, dim_str, dtypes, name):
                 index_variadic = array_type.index_variadic + len(dims)
             else:
                 raise ValueError(
-                    "Cannot use multiple-dimension specifiers (`*name` or `...`) "
+                    "Cannot use variadic specifiers (`*name` or `...`) "
                     "in both the original array and the extended array"
                 )
         dims = dims + array_type.dims

--- a/jaxtyping/_array_types.py
+++ b/jaxtyping/_array_types.py
@@ -28,7 +28,12 @@ from typing import Any, Literal, NoReturn, Optional, Union
 import numpy as np
 
 from ._raise import jaxtyping_raise, jaxtyping_raise_from
-from ._storage import get_shape_memo, get_treepath_memo, set_shape_memo
+from ._storage import (
+    get_shape_memo,
+    get_treeflatten_memo,
+    get_treepath_memo,
+    set_shape_memo,
+)
 
 
 try:
@@ -160,6 +165,8 @@ class _MetaAbstractArray(type):
     def __instancecheck__(cls, obj):
         if not isinstance(obj, cls.array_type):
             return False
+        if get_treeflatten_memo():
+            return True
 
         if hasattr(obj.dtype, "type") and hasattr(obj.dtype.type, "__name__"):
             # JAX, numpy

--- a/jaxtyping/_array_types.py
+++ b/jaxtyping/_array_types.py
@@ -498,6 +498,16 @@ def _make_array(array_type, dim_str, dtypes, name):
             return array_type
         else:
             return _not_made
+    elif array_type is np.bool_:
+        if _check_scalar("bool", dtypes, dims):
+            return array_type
+        else:
+            return _not_made
+    elif array_type is np.generic or array_type is np.number:
+        if _check_scalar("", dtypes, dims):
+            return array_type
+        else:
+            return _not_made
     if issubclass(array_type, AbstractArray):
         if dtypes is _any_dtype:
             dtypes = array_type.dtypes

--- a/jaxtyping/_decorator.py
+++ b/jaxtyping/_decorator.py
@@ -687,17 +687,25 @@ def _exc_shape_info(memos) -> str:
     Used in type-checking error messages.
     """
     single_memo, variadic_memo, pytree_memo, _ = memos
+    single_memo = {
+        name: size
+        for name, size in single_memo.items()
+        if not name.startswith("~~delete~~")
+    }
+    variadic_memo = {
+        name: shape
+        for name, (_, shape) in variadic_memo.items()
+        if not name.startswith("~~delete~~")
+    }
     pieces = []
     if len(single_memo) > 0 or len(variadic_memo) > 0:
         pieces.append(
             "The current values for each jaxtyping axis annotation are as follows."
         )
         for name, size in single_memo.items():
-            if not name.startswith("~~delete~~"):
-                pieces.append(f"{name}={size}")
-        for name, (_, shape) in variadic_memo.items():
-            if not name.startswith("~~delete~~"):
-                pieces.append(f"{name}={shape}")
+            pieces.append(f"{name}={size}")
+        for name, shape in variadic_memo.items():
+            pieces.append(f"{name}={shape}")
     if len(pytree_memo) > 0:
         pieces.append(
             "The current values for each jaxtyping PyTree structure annotation are as "

--- a/jaxtyping/_import_hook.py
+++ b/jaxtyping/_import_hook.py
@@ -109,7 +109,7 @@ class Typechecker:
 
         elif typechecker is None:
             # If it is None, ignore it silently (use dummy decorator)
-            self.hash = 0
+            self.hash = "0"
             Typechecker.lookup[self.hash] = lambda x, *_, **__: x
         else:
             # Passed typechecker is invalid

--- a/jaxtyping/_pytree_type.py
+++ b/jaxtyping/_pytree_type.py
@@ -53,19 +53,24 @@ class _MetaPyTree(type):
         if not hasattr(cls, "leaftype"):
             return True  # Just `isinstance(x, PyTree)`
 
-        single_memo, variadic_memo, pytree_memo = get_shape_memo()
+        single_memo, variadic_memo, pytree_memo, arg_memo = get_shape_memo()
         single_memo_bak = single_memo.copy()
         variadic_memo_bak = variadic_memo.copy()
         pytree_memo_bak = pytree_memo.copy()
+        arg_memo_bak = arg_memo.copy()
         try:
             out = cls._check(obj, pytree_memo)
         except Exception:
-            set_shape_memo(single_memo_bak, variadic_memo_bak, pytree_memo_bak)
+            set_shape_memo(
+                single_memo_bak, variadic_memo_bak, pytree_memo_bak, arg_memo_bak
+            )
             raise
         if out:
             return True
         else:
-            set_shape_memo(single_memo_bak, variadic_memo_bak, pytree_memo_bak)
+            set_shape_memo(
+                single_memo_bak, variadic_memo_bak, pytree_memo_bak, arg_memo_bak
+            )
             return False
 
     def _check(cls, obj, pytree_memo):

--- a/jaxtyping/_pytree_type.py
+++ b/jaxtyping/_pytree_type.py
@@ -54,6 +54,10 @@ class _MetaPyTree(type):
     def __instancecheck__(cls, obj):
         if not hasattr(cls, "leaftype"):
             return True  # Just `isinstance(x, PyTree)`
+        # Handle beartype doing `isinstance(None, hint)` to check if
+        # is `instance`able.
+        if obj is None:
+            return True
 
         single_memo, variadic_memo, pytree_memo, arg_memo = get_shape_memo()
         single_memo_bak = single_memo.copy()

--- a/jaxtyping/_raise.py
+++ b/jaxtyping/_raise.py
@@ -1,0 +1,22 @@
+from typing import NoReturn
+
+
+def jaxtyping_raise(e) -> NoReturn:
+    """Raises `e`, whilst adding a tag that it should not be intercepted by
+    `TypeCheckError`. All `raise` statements from within `__instancecheck__` should use
+    this.
+    """
+    try:
+        raise e
+    except Exception as f:
+        f._jaxtyping_malformed = True
+        raise
+
+
+def jaxtyping_raise_from(e, e_base) -> NoReturn:
+    __tracebackhide__ = True
+    try:
+        raise e from e_base
+    except Exception as f:
+        f._jaxtyping_malformed = True
+        raise

--- a/jaxtyping/_raise.py
+++ b/jaxtyping/_raise.py
@@ -6,6 +6,7 @@ def jaxtyping_raise(e) -> NoReturn:
     `TypeCheckError`. All `raise` statements from within `__instancecheck__` should use
     this.
     """
+    __tracebackhide__ = True
     try:
         raise e
     except Exception as f:

--- a/jaxtyping/_storage.py
+++ b/jaxtyping/_storage.py
@@ -20,6 +20,8 @@
 import threading
 from typing import Optional
 
+from ._raise import jaxtyping_raise
+
 
 _shape_storage = threading.local()
 
@@ -70,10 +72,12 @@ def clear_treepath_memo() -> None:
 
 def set_treepath_memo(index: Optional[int], structure: str) -> None:
     if hasattr(_treepath_storage, "value") and _treepath_storage.value is not None:
-        raise ValueError(
-            "Cannot typecheck annotations of the form "
-            "`PyTree[PyTree[Shaped[Array, '?foo'], 'T'], 'S']` as it is ambiguous "
-            "which PyTree the `?` annotation refers to."
+        jaxtyping_raise(
+            ValueError(
+                "Cannot typecheck annotations of the form "
+                "`PyTree[PyTree[Shaped[Array, '?foo'], 'T'], 'S']` as it is ambiguous "
+                "which PyTree the `?` annotation refers to."
+            )
         )
     if index is None:
         _treepath_storage.value = f"~~delete~~({structure}) "
@@ -84,9 +88,11 @@ def set_treepath_memo(index: Optional[int], structure: str) -> None:
 
 def get_treepath_memo() -> str:
     if not hasattr(_treepath_storage, "value") or _treepath_storage.value is None:
-        raise ValueError(
-            "Cannot use `?` annotations, e.g. `Shaped[Array, '?foo']`, except "
-            "when contained with structured `PyTree` annotations, e.g. "
-            "`PyTree[Shaped[Array, '?foo'], 'T']`."
+        jaxtyping_raise(
+            ValueError(
+                "Cannot use `?` annotations, e.g. `Shaped[Array, '?foo']`, except "
+                "when contained with structured `PyTree` annotations, e.g. "
+                "`PyTree[Shaped[Array, '?foo'], 'T']`."
+            )
         )
     return _treepath_storage.value

--- a/jaxtyping/_storage.py
+++ b/jaxtyping/_storage.py
@@ -104,3 +104,21 @@ def get_treepath_memo() -> str:
             )
         )
     return _treepath_storage.value
+
+
+_treeflatten_storage = threading.local()
+
+
+def clear_treeflatten_memo() -> None:
+    _treeflatten_storage.value = False
+
+
+def set_treeflatten_memo():
+    _treeflatten_storage.value = True
+
+
+def get_treeflatten_memo():
+    try:
+        return _treeflatten_storage.value
+    except AttributeError:
+        return False

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,6 +41,29 @@ def typecheck(request):
     return request.param
 
 
+@pytest.fixture(params=(False, True))
+def jaxtyp(request):
+    import jaxtyping
+
+    if request.param:
+        # New-style
+        # @jaxtyping.jaxtyped(typechecker=typechecker)
+        # def f(...)
+        return lambda typechecker: jaxtyping.jaxtyped(typechecker=typechecker)
+    else:
+        # Old-style
+        # @jaxtyping.jaxtyped
+        # @typechecker
+        # def f(...)
+        def impl(typechecker):
+            def decorator(fn):
+                return jaxtyping.jaxtyped(typechecker(fn))
+
+            return decorator
+
+        return impl
+
+
 @pytest.fixture()
 def getkey():
     def _getkey():

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -33,7 +33,6 @@ from jaxtyping import (
     Bool,
     Float,
     Float32,
-    jaxtyped,
     PRNGKeyArray,
     Shaped,
 )
@@ -41,9 +40,8 @@ from jaxtyping import (
 from .helpers import ParamError, ReturnError
 
 
-def test_basic(typecheck):
-    @jaxtyped
-    @typecheck
+def test_basic(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
     def g(x: Shaped[Array, "..."]):
         pass
 
@@ -82,16 +80,14 @@ def test_dtypes():
             assert key == val.__name__
 
 
-def test_return(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_return(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Float[Array, "b c"]) -> Float[Array, "c b"]:
         return jnp.transpose(x)
 
     g(jr.normal(getkey(), (3, 4)))
 
-    @jaxtyped
-    @typecheck
+    @jaxtyp(typecheck)
     def h(x: Float[Array, "b c"]) -> Float[Array, "b c"]:
         return jnp.transpose(x)
 
@@ -99,9 +95,8 @@ def test_return(typecheck, getkey):
         h(jr.normal(getkey(), (3, 4)))
 
 
-def test_two_args(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_two_args(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Shaped[Array, "b c"], y: Shaped[Array, "c d"]):
         return x @ y
 
@@ -109,8 +104,7 @@ def test_two_args(typecheck, getkey):
     with pytest.raises(ParamError):
         g(jr.normal(getkey(), (3, 4)), jr.normal(getkey(), (5, 4)))
 
-    @jaxtyped
-    @typecheck
+    @jaxtyp(typecheck)
     def h(x: Shaped[Array, "b c"], y: Shaped[Array, "c d"]) -> Shaped[Array, "b d"]:
         return x @ y
 
@@ -119,9 +113,8 @@ def test_two_args(typecheck, getkey):
         h(jr.normal(getkey(), (3, 4)), jr.normal(getkey(), (5, 4)))
 
 
-def test_any_dtype(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_any_dtype(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Shaped[Array, "a b"]) -> Shaped[Array, "a b"]:
         return x
 
@@ -136,14 +129,12 @@ def test_any_dtype(typecheck, getkey):
         g(jr.normal(getkey(), (1,)))
 
 
-def test_nested_jaxtyped(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_nested_jaxtyped(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Float32[Array, "b c"], transpose: bool) -> Float32[Array, "c b"]:
         return h(x, transpose)
 
-    @jaxtyped
-    @typecheck
+    @jaxtyp(typecheck)
     def h(x: Float32[Array, "c b"], transpose: bool) -> Float32[Array, "b c"]:
         if transpose:
             return jnp.transpose(x)
@@ -157,9 +148,8 @@ def test_nested_jaxtyped(typecheck, getkey):
         g(jr.normal(getkey(), (2, 3)), False)
 
 
-def test_nested_nojaxtyped(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_nested_nojaxtyped(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Float32[Array, "b c"]):
         return h(x)
 
@@ -171,9 +161,8 @@ def test_nested_nojaxtyped(typecheck, getkey):
         g(jr.normal(getkey(), (2, 3)))
 
 
-def test_isinstance(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_isinstance(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Float32[Array, "b c"]) -> Float32[Array, " z"]:
         y = jnp.transpose(x)
         assert isinstance(y, Float32[Array, "c b"])
@@ -187,9 +176,8 @@ def test_isinstance(typecheck, getkey):
     g(jr.normal(getkey(), (2, 3)))
 
 
-def test_fixed(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_fixed(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(
         x: Float32[Array, "4 5 foo"], y: Float32[Array, " foo"]
     ) -> Float32[Array, "4 5"]:
@@ -204,9 +192,8 @@ def test_fixed(typecheck, getkey):
         g(c, b)
 
 
-def test_anonymous(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_anonymous(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Float32[Array, "foo _"], y: Float32[Array, " _"]):
         pass
 
@@ -215,9 +202,8 @@ def test_anonymous(typecheck, getkey):
     g(a, b)
 
 
-def test_named_variadic(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_named_variadic(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(
         x: Float32[Array, "*batch foo"],
         y: Float32[Array, " *batch"],
@@ -240,8 +226,7 @@ def test_named_variadic(typecheck, getkey):
     with pytest.raises(ParamError):
         g(a2, b1, c)
 
-    @jaxtyped
-    @typecheck
+    @jaxtyp(typecheck)
     def h(x: Float32[Array, " foo *batch"], y: Float32[Array, " foo *batch bar"]):
         pass
 
@@ -255,9 +240,8 @@ def test_named_variadic(typecheck, getkey):
         h(b, c)
 
 
-def test_anonymous_variadic(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_anonymous_variadic(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Float32[Array, "... foo"], y: Float32[Array, " foo"]):
         pass
 
@@ -277,9 +261,8 @@ def test_anonymous_variadic(typecheck, getkey):
         g(a3, c)
 
 
-def test_broadcast_fixed(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_broadcast_fixed(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Float32[Array, "#4"]):
         pass
 
@@ -290,9 +273,8 @@ def test_broadcast_fixed(typecheck, getkey):
         g(jr.normal(getkey(), (3,)))
 
 
-def test_broadcast_named(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_broadcast_named(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Float32[Array, " #foo"], y: Float32[Array, " #foo"]):
         pass
 
@@ -314,9 +296,8 @@ def test_broadcast_named(typecheck, getkey):
         g(b, a)
 
 
-def test_broadcast_variadic_named(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_broadcast_variadic_named(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: Float32[Array, " *#foo"], y: Float32[Array, " *#foo"]):
         pass
 
@@ -373,9 +354,8 @@ def test_broadcast_variadic_named(typecheck, getkey):
         g(o, a)
 
 
-def test_variadic_mixed_broadcast1(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_variadic_mixed_broadcast(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def f(x: Float[Array, " *foo"], y: Float[Array, " #*foo"]):
         pass
 
@@ -389,9 +369,8 @@ def test_variadic_mixed_broadcast1(typecheck, getkey):
     f(c, d)
 
 
-def test_variadic_mixed_broadcast2(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_variadic_mixed_broadcast2(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def f(x: Float[Array, " *#foo"], y: Float[Array, " *foo"]):
         pass
 
@@ -405,9 +384,8 @@ def test_variadic_mixed_broadcast2(typecheck, getkey):
     f(c, d)
 
 
-def test_variadic_mixed_broadcast3(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_variadic_mixed_broadcast3(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def f(
         x: Float[Array, "*B L D"],
         *,
@@ -427,24 +405,20 @@ def test_no_commas():
         Float32[Array, "foo, bar"]
 
 
-def test_symbolic(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_symbolic(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def make_slice(x: Float32[Array, " dim"]) -> Float32[Array, " dim-1"]:
         return x[1:]
 
-    @jaxtyped
-    @typecheck
+    @jaxtyp(typecheck)
     def cat(x: Float32[Array, " dim"]) -> Float32[Array, " 2*dim"]:
         return jnp.concatenate([x, x])
 
-    @jaxtyped
-    @typecheck
+    @jaxtyp(typecheck)
     def bad_make_slice(x: Float32[Array, " dim"]) -> Float32[Array, " dim-1"]:
         return x
 
-    @jaxtyped
-    @typecheck
+    @jaxtyp(typecheck)
     def bad_cat(x: Float32[Array, " dim"]) -> Float32[Array, " 2*dim"]:
         return jnp.concatenate([x, x, x])
 
@@ -464,9 +438,8 @@ def test_symbolic(typecheck, getkey):
         bad_cat(x)
 
 
-def test_incomplete_symbolic(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_incomplete_symbolic(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def foo(x: Float32[Array, " 2*dim"]):
         pass
 
@@ -573,9 +546,8 @@ def test_py310_unions():
     assert isinstance(x, get_args(y))
 
 
-def test_key(typecheck):
-    @jaxtyped
-    @typecheck
+def test_key(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
     def f(x: PRNGKeyArray):
         pass
 
@@ -592,7 +564,7 @@ def test_key(typecheck):
         f(jnp.array(3.0))
 
 
-def test_extension(typecheck, getkey):
+def test_extension(jaxtyp, typecheck, getkey):
     X = Shaped[Array, "a b"]
     Y = Shaped[X, "c d"]
     Z = Shaped[Array, "c d a b"]
@@ -601,8 +573,7 @@ def test_extension(typecheck, getkey):
     X = Float[Array, "a"]
     Y = Float[X, "b"]
 
-    @jaxtyped
-    @typecheck
+    @jaxtyp(typecheck)
     def f(a: X, b: Y):
         ...
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -33,7 +33,9 @@ from jaxtyping import (
     Bool,
     Float,
     Float32,
+    Key,
     PRNGKeyArray,
+    Scalar,
     Shaped,
 )
 
@@ -586,8 +588,8 @@ def test_key(jaxtyp, typecheck):
     def f(x: PRNGKeyArray):
         pass
 
-    x = jr.PRNGKey(0)
-    f(x)
+    f(jr.key(0))
+    f(jr.PRNGKey(0))
 
     with pytest.raises(ParamError):
         f(object())
@@ -597,6 +599,30 @@ def test_key(jaxtyp, typecheck):
         f(jnp.array(3))
     with pytest.raises(ParamError):
         f(jnp.array(3.0))
+
+
+def test_key_dtype(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
+    def f1(x: Key[Array, ""]):
+        pass
+
+    @jaxtyp(typecheck)
+    def f2(x: Key[Scalar, ""]):
+        pass
+
+    for f in (f1, f2):
+        f(jr.key(0))
+
+        with pytest.raises(ParamError):
+            f(jr.PRNGKey(0))
+        with pytest.raises(ParamError):
+            f(object())
+        with pytest.raises(ParamError):
+            f(1)
+        with pytest.raises(ParamError):
+            f(jnp.array(3))
+        with pytest.raises(ParamError):
+            f(jnp.array(3.0))
 
 
 def test_extension(jaxtyp, typecheck, getkey):

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -496,22 +496,18 @@ def test_arraylike(typecheck, getkey):
     assert set(get_args(floatlike1)) == {
         Float32[Array, ""],
         Float32[np.ndarray, ""],
-        Float32[np.bool_, ""],
         Float32[np.number, ""],
         float,
     }
     assert set(get_args(floatlike2)) == {
         Float[Array, ""],
         Float[np.ndarray, ""],
-        Float[np.bool_, ""],
         Float[np.number, ""],
         float,
     }
     assert set(get_args(floatlike3)) == {
         Float32[Array, "4"],
         Float32[np.ndarray, "4"],
-        Float32[np.bool_, "4"],
-        Float32[np.number, "4"],
     }
 
     shaped1 = Shaped[ArrayLike, ""]
@@ -531,8 +527,6 @@ def test_arraylike(typecheck, getkey):
     assert set(get_args(shaped2)) == {
         Shaped[Array, "4"],
         Shaped[np.ndarray, "4"],
-        Shaped[np.bool_, "4"],
-        Shaped[np.number, "4"],
     }
 
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -17,6 +17,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import dataclasses as dc
 import sys
 from typing import get_args, get_origin, Union
 
@@ -33,6 +34,7 @@ from jaxtyping import (
     Bool,
     Float,
     Float32,
+    jaxtyped,
     Key,
     PRNGKeyArray,
     Scalar,
@@ -483,6 +485,19 @@ def test_deferred_symbolic_bad(jaxtyp, typecheck):
 
     with pytest.raises(ReturnError):
         A().bar(jnp.array(0.0))
+
+
+def test_deferred_symbolic_dataclass(typecheck):
+    @jaxtyped(typechecker=typecheck)
+    @dc.dataclass
+    class A:
+        value: int
+        array: Float[Array, " {self.value}"]
+
+    A(3, jnp.zeros(3))
+
+    with pytest.raises(ParamError):
+        A(3, jnp.zeros(4))
 
 
 def test_arraylike(typecheck, getkey):

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -110,7 +110,7 @@ def test_varkwargs(jaxtyp, typecheck):
 
 def test_defaults(jaxtyp, typecheck):
     @jaxtyp(typecheck)
-    def f(x, y=1):
+    def f(x: int, y=1):
         pass
 
     f(1)

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -1,8 +1,11 @@
 import abc
 
 import jax.random as jr
+import pytest
 
 from jaxtyping import Array, Float, jaxtyped
+
+from .helpers import ParamError, ReturnError
 
 
 class M(metaclass=abc.ABCMeta):
@@ -85,3 +88,77 @@ def test_context(getkey):
     with jaxtyped("context"):
         assert isinstance(a, Float[Array, "foo bar"])
         assert not isinstance(b, Float[Array, "foo"])
+
+
+def test_varargs(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
+    def f(*args):
+        pass
+
+    f(1, 2)
+
+
+def test_varkwargs(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
+    def f(**kwargs):
+        pass
+
+    f(a=1, b=2)
+
+
+def test_defaults(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
+    def f(x, y=1):
+        pass
+
+    f(1)
+
+
+class _GlobalFoo:
+    pass
+
+
+def test_global_stringified_annotation(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
+    def f(x: "_GlobalFoo") -> "_GlobalFoo":
+        return x
+
+    f(_GlobalFoo())
+
+    @jaxtyp(typecheck)
+    def g(x: int) -> "_GlobalFoo":
+        return x
+
+    @jaxtyp(typecheck)
+    def h(x: "_GlobalFoo") -> int:
+        return x
+
+    with pytest.raises(ReturnError):
+        g(1)
+
+    with pytest.raises(ParamError):
+        h(1)
+
+
+# This test does not use `jaxtyp(typecheck)` because typeguard does some evil stack
+# frame introspection to try and grab local variables.
+def test_local_stringified_annotation(typecheck):
+    class LocalFoo:
+        pass
+
+    @jaxtyped(typechecker=typecheck)
+    def f(x: "LocalFoo") -> "LocalFoo":
+        return x
+
+    f(LocalFoo())
+
+    @jaxtyped
+    @typecheck
+    def g(x: "LocalFoo") -> "LocalFoo":
+        return x
+
+    g(LocalFoo())
+
+    # We don't check that errors are raised if it goes wrong, since we can't usually
+    # resolve local type annotations at runtime. Best we can hope for is not to raise
+    # a spurious error about not being able to find the type.

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -88,6 +88,8 @@ def test_context(getkey):
     with jaxtyped("context"):
         assert isinstance(a, Float[Array, "foo bar"])
         assert not isinstance(b, Float[Array, "foo"])
+    assert isinstance(a, Float[Array, "foo bar"])
+    assert isinstance(b, Float[Array, "foo"])
 
 
 def test_varargs(jaxtyp, typecheck):

--- a/test/test_messages.py
+++ b/test/test_messages.py
@@ -1,0 +1,108 @@
+from typing import Any
+
+import equinox as eqx
+import jax.numpy as jnp
+import pytest
+
+from jaxtyping import Array, Float, jaxtyped, PyTree, TypeCheckError
+
+
+def test_arg_localisation(typecheck):
+    @jaxtyped(typechecker=typecheck)
+    def f(x: str, y: str, z: int):
+        pass
+
+    matches = [
+        "Type-check error whilst checking the parameters of f",
+        "The problem arose whilst typechecking argument 'z'.",
+        r"Called with args: \('hi', 'bye', 'not-an-int'\)",
+        "Called with kwargs: {}",
+        r"Parameter annotations: \(x: str, y: str, z: int\).",
+    ]
+    for match in matches:
+        with pytest.raises(TypeCheckError, match=match):
+            f("hi", "bye", "not-an-int")
+
+    @jaxtyped(typechecker=typecheck)
+    def g(x: Float[Array, "a b"], y: Float[Array, "b c"]):
+        pass
+
+    x = jnp.zeros((2, 3))
+    y = jnp.zeros((4, 3))
+    matches = [
+        "Type-check error whilst checking the parameters of g",
+        "The problem arose whilst typechecking argument 'y'.",
+        r"Called with args: \(f32\[2,3\],\)",
+        r"Called with kwargs: {'y': f32\[4,3\]}",
+        (
+            r"Parameter annotations: \(x: Float\[Array, 'a b'\], y: "
+            r"Float\[Array, 'b c'\]\)."
+        ),
+        "The current values for each jaxtyping axis annotation are as follows.",
+        "a=2",
+        "b=3",
+    ]
+    for match in matches:
+        with pytest.raises(TypeCheckError, match=match):
+            g(x, y=y)
+
+
+def test_return(typecheck):
+    @jaxtyped(typechecker=typecheck)
+    def f(x: PyTree[Any, " T"], y: PyTree[Any, " S"]) -> PyTree[Any, "T S"]:
+        return "foo"
+
+    x = (1, 2)
+    y = {"a": 1}
+    matches = [
+        "Type-check error whilst checking the return value of f",
+        r"Called with args: \(\(1, 2\),\)",
+        r"Called with kwargs: {'y': {'a': 1}}",
+        "Return value: 'foo'",
+        r"Return annotation: PyTree\[Any, \"T S\"\].",
+        (
+            "The current values for each jaxtyping PyTree structure annotation are as "
+            "follows."
+        ),
+        r"T=PyTreeDef\(\(\*, \*\)\)",
+        r"S=PyTreeDef\({'a': \*}\)",
+    ]
+    for match in matches:
+        with pytest.raises(TypeCheckError, match=match):
+            f(x, y=y)
+
+
+def test_dataclass_attribute(typecheck):
+    @jaxtyped(typechecker=typecheck)
+    class M(eqx.Module):
+        x: Float[Array, " *foo"]
+        y: PyTree[Any, " T"]
+        z: int
+
+    x = jnp.zeros((2, 3))
+    y = (1, (3, 4))
+    z = "not-an-int"
+
+    matches = [
+        "Type-check error whilst checking the parameters of M",
+        "The problem arose whilst typechecking argument 'z'.",
+        r"Called with args: \(\)",
+        (
+            r"Called with kwargs: {'x': f32\[2,3\], 'y': \(1, \(3, 4\)\), "
+            r"'z': 'not-an-int'}"
+        ),
+        (
+            r"Parameter annotations: \(x: Float\[Array, '\*foo'\], "
+            r"y: PyTree\[Any, \"T\"\], z: int\)."
+        ),
+        "The current values for each jaxtyping axis annotation are as follows.",
+        r"foo=\(2, 3\)",
+        (
+            "The current values for each jaxtyping PyTree structure annotation are as "
+            "follows."
+        ),
+        r"T=PyTreeDef\(\(\*, \(\*, \*\)\)\)",
+    ]
+    for match in matches:
+        with pytest.raises(TypeCheckError, match=match):
+            M(x, y, z)

--- a/test/test_messages.py
+++ b/test/test_messages.py
@@ -15,8 +15,7 @@ def test_arg_localisation(typecheck):
     matches = [
         "Type-check error whilst checking the parameters of f",
         "The problem arose whilst typechecking argument 'z'.",
-        r"Called with args: \('hi', 'bye', 'not-an-int'\)",
-        "Called with kwargs: {}",
+        "Called with arguments: {'x': 'hi', 'y': 'bye', 'z': 'not-an-int'}",
         r"Parameter annotations: \(x: str, y: str, z: int\).",
     ]
     for match in matches:
@@ -32,8 +31,7 @@ def test_arg_localisation(typecheck):
     matches = [
         "Type-check error whilst checking the parameters of g",
         "The problem arose whilst typechecking argument 'y'.",
-        r"Called with args: \(f32\[2,3\],\)",
-        r"Called with kwargs: {'y': f32\[4,3\]}",
+        r"Called with arguments: {'x': f32\[2,3\], 'y': f32\[4,3\]}",
         (
             r"Parameter annotations: \(x: Float\[Array, 'a b'\], y: "
             r"Float\[Array, 'b c'\]\)."
@@ -56,8 +54,7 @@ def test_return(typecheck):
     y = {"a": 1}
     matches = [
         "Type-check error whilst checking the return value of f",
-        r"Called with args: \(\(1, 2\),\)",
-        r"Called with kwargs: {'y': {'a': 1}}",
+        r"Called with arguments: {'x': \(1, 2\), 'y': {'a': 1}}",
         "Return value: 'foo'",
         r"Return annotation: PyTree\[Any, \"T S\"\].",
         (
@@ -86,13 +83,12 @@ def test_dataclass_attribute(typecheck):
     matches = [
         "Type-check error whilst checking the parameters of M",
         "The problem arose whilst typechecking argument 'z'.",
-        r"Called with args: \(\)",
         (
-            r"Called with kwargs: {'x': f32\[2,3\], 'y': \(1, \(3, 4\)\), "
-            r"'z': 'not-an-int'}"
+            r"Called with arguments: {'self': M\(\.\.\.\), 'x': f32\[2,3\], "
+            r"'y': \(1, \(3, 4\)\), 'z': 'not-an-int'}"
         ),
         (
-            r"Parameter annotations: \(x: Float\[Array, '\*foo'\], "
+            r"Parameter annotations: \(self: Any, x: Float\[Array, '\*foo'\], "
             r"y: PyTree\[Any, \"T\"\], z: int\)."
         ),
         "The current values for each jaxtyping axis annotation are as follows.",

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -26,7 +26,7 @@ import jax.random as jr
 import pytest
 
 import jaxtyping
-from jaxtyping import Array, Float, jaxtyped, PyTree
+from jaxtyping import Array, Float, PyTree
 
 from .helpers import make_mlp, ParamError
 
@@ -93,9 +93,8 @@ def test_nested_pytrees(getkey, typecheck):
         g([1, 2, make_mlp()])
 
 
-def test_pytree_array(typecheck):
-    @jaxtyped
-    @typecheck
+def test_pytree_array(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
     def g(x: PyTree[Float[jnp.ndarray, "..."]]):
         pass
 
@@ -107,9 +106,8 @@ def test_pytree_array(typecheck):
         g(1.0)
 
 
-def test_pytree_shaped_array(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_pytree_shaped_array(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def g(x: PyTree[Float[jnp.ndarray, "b c"]]):
         pass
 
@@ -196,9 +194,8 @@ def test_subclass_pytree():
     assert not issubclass(int, PyTree)
 
 
-def test_structure_match(typecheck):
-    @jaxtyped
-    @typecheck
+def test_structure_match(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
     def f(x: PyTree[int, " T"], y: PyTree[str, " T"]):
         pass
 
@@ -209,9 +206,8 @@ def test_structure_match(typecheck):
         f(1, ("hi",))
 
 
-def test_structure_prefix(typecheck):
-    @jaxtyped
-    @typecheck
+def test_structure_prefix(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
     def f(x: PyTree[int, " T"], y: PyTree[str, "T ..."]):
         pass
 
@@ -228,9 +224,8 @@ def test_structure_prefix(typecheck):
         f((3, 4, 5), {"a": ("hi", "bye")})
 
 
-def test_structure_suffix(typecheck):
-    @jaxtyped
-    @typecheck
+def test_structure_suffix(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
     def f(x: PyTree[int, " T"], y: PyTree[str, "... T"]):
         pass
 
@@ -245,9 +240,8 @@ def test_structure_suffix(typecheck):
         f((3, 4, 5), {"a": ("hi", "bye")})
 
 
-def test_structure_compose(typecheck):
-    @jaxtyped
-    @typecheck
+def test_structure_compose(jaxtyp, typecheck):
+    @jaxtyp(typecheck)
     def f(x: PyTree[int, " T"], y: PyTree[int, " S"], z: PyTree[str, "S T"]):
         pass
 
@@ -262,8 +256,7 @@ def test_structure_compose(typecheck):
     with pytest.raises(ParamError):
         f((1, 2), {"a": 3}, ({"a": "hi"}, {"a": "bye"}))
 
-    @jaxtyped
-    @typecheck
+    @jaxtyp(typecheck)
     def g(x: PyTree[int, " T"], y: PyTree[int, " S"], z: PyTree[str, "T S"]):
         pass
 
@@ -274,7 +267,7 @@ def test_structure_compose(typecheck):
 
 
 @pytest.mark.parametrize("variadic", (False, True))
-def test_treepath_dependence_function(variadic, typecheck, getkey):
+def test_treepath_dependence_function(variadic, jaxtyp, typecheck, getkey):
     if variadic:
         jtshape = "*?foo"
         shape = (2, 3)
@@ -282,8 +275,7 @@ def test_treepath_dependence_function(variadic, typecheck, getkey):
         jtshape = "?foo"
         shape = (4,)
 
-    @jaxtyped
-    @typecheck
+    @jaxtyp(typecheck)
     def f(
         x: PyTree[Float[Array, jtshape], " T"], y: PyTree[Float[Array, jtshape], " T"]
     ):
@@ -312,7 +304,7 @@ def test_treepath_dependence_dataclass(variadic, typecheck, getkey):
         jtshape = "?foo"
         shape = (4,)
 
-    @jaxtyping._decorator._jaxtyped_typechecker(typecheck)
+    @jaxtyping.jaxtyped(typechecker=typecheck)
     class A(eqx.Module):
         x: PyTree[Float[Array, jtshape], " T"]
         y: PyTree[Float[Array, jtshape], " T"]
@@ -331,9 +323,8 @@ def test_treepath_dependence_dataclass(variadic, typecheck, getkey):
         A((x1, x2), (y2, y1))
 
 
-def test_treepath_dependence_missing_structure_annotation(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_treepath_dependence_missing_structure_annotation(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def f(x: PyTree[Float[Array, "?foo"], " T"], y: PyTree[Float[Array, "?foo"]]):
         pass
 
@@ -343,9 +334,8 @@ def test_treepath_dependence_missing_structure_annotation(typecheck, getkey):
         f(x1, y1)
 
 
-def test_treepath_dependence_multiple_structure_annotation(typecheck, getkey):
-    @jaxtyped
-    @typecheck
+def test_treepath_dependence_multiple_structure_annotation(jaxtyp, typecheck, getkey):
+    @jaxtyp(typecheck)
     def f(x: PyTree[PyTree[Float[Array, "?foo"], " S"], " T"]):
         pass
 


### PR DESCRIPTION
Phew, this ended up being a pretty complicated change!
The basic summary is that we now support the syntax
```
@jaxtyped(typechecker=typechecker)
def f(...): ...
```
and when using this, we now get pretty error messages about what went
wrong.

(
The old syntax, i.e.
```
@jaxtyped
@typechecker
def f(...): ...
```
is still supported, but doesn't give much information.
)

The internals of this do quite a lot of magic! In particular we
dynamically create quite a lot of functions and test the provided
arguments against their signatures. The overhead should still be
minimal under `jax.jit`, though.
(TODO: what's the overhead like in non-jit situations, e.g. PyTorch?
I've tried to minimise the overhead throughout just to be sure, but
perhaps PyTorch users should stick to the old syntax?)
