### PR TITLE
chore(docs): fix typos in docstrings

### DIFF
--- a/jaxtyping/_decorator.py
+++ b/jaxtyping/_decorator.py
@@ -83,7 +83,7 @@ def jaxtyped(fn=_sentinel, *, typechecker=_sentinel):
         @dataclass
         class MyDataclass:
             x: int
-            y: Float[Array "b c"]
+            y: Float[Array, "b c"]
         ```
 
     **Arguments:**
@@ -476,7 +476,7 @@ class _JaxtypingContext:
 def _check_dataclass_annotations(self, typechecker):
     """Creates and calls a function that checks the attributes of `self`
 
-    `self` should be a dataclass instancae. `typechecker` should be e.g.
+    `self` should be a dataclass instance. `typechecker` should be e.g.
     `beartype.beartype` or `typeguard.typechecked`.
     """
     parameters = [inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD)]


### PR DESCRIPTION
Hello!

This is a small PR to fix typos in docstrings.

Maybe, I would suggest adding an import for `dataclass` in the example (otherwise it will not run), and maybe indicate that it works with other dataclass decorators, like the `dataclass` decorator from chex.