### PR TITLE
Update dataclass docs

### DIFF
--- a/jaxtyping/_decorator.py
+++ b/jaxtyping/_decorator.py
@@ -79,6 +79,8 @@ def jaxtyped(fn=_sentinel, *, typechecker=_sentinel):
             return x[:, :, None] * y[:, None, :]
 
         # Type-check a dataclass
+        from dataclasses import dataclass
+        
         @jaxtyped(typechecker=typechecker)
         @dataclass
         class MyDataclass:
@@ -88,7 +90,18 @@ def jaxtyped(fn=_sentinel, *, typechecker=_sentinel):
 
     **Arguments:**
 
-    - `fn`: The function or dataclass to decorate.
+    - `fn`: The function or dataclass to decorate. In practice if you want to use
+        dataclasses with JAX, then
+        [`equinox.Module`](https://github.com/patrick-kidger/equinox) is our recommended
+        approach:
+        ```python
+        import equinox as eqx
+        
+        @jaxtyped(typechecker=typechecker)
+        class MyModule(eqx.Module):
+            ...
+        ```
+
     - `typechecker`: Keyword-only argument: the runtime type-checker to use. This should
         be a function decorator that will raise an exception if there is a type error,
         e.g.

--- a/jaxtyping/_decorator.py
+++ b/jaxtyping/_decorator.py
@@ -80,7 +80,7 @@ def jaxtyped(fn=_sentinel, *, typechecker=_sentinel):
 
         # Type-check a dataclass
         from dataclasses import dataclass
-        
+
         @jaxtyped(typechecker=typechecker)
         @dataclass
         class MyDataclass:
@@ -96,7 +96,7 @@ def jaxtyped(fn=_sentinel, *, typechecker=_sentinel):
         approach:
         ```python
         import equinox as eqx
-        
+
         @jaxtyped(typechecker=typechecker)
         class MyModule(eqx.Module):
             ...

--- a/jaxtyping/_decorator.py
+++ b/jaxtyping/_decorator.py
@@ -92,8 +92,8 @@ def jaxtyped(fn=_sentinel, *, typechecker=_sentinel):
 
     - `fn`: The function or dataclass to decorate. In practice if you want to use
         dataclasses with JAX, then
-        [`equinox.Module`](https://github.com/patrick-kidger/equinox) is our recommended
-        approach:
+        [`equinox.Module`](https://docs.kidger.site/equinox/api/module/module/) is our
+        recommended approach:
         ```python
         import equinox as eqx
 


### PR DESCRIPTION
@jeertmans -- updated the dataclass docs as suggested in #154. In practice I'm recommending `equinox.Module` rather than `chex.dataclass`, as it's a bit safer for most purposes + it's part of the same tech stack as jaxtyping / etc.